### PR TITLE
feat: add rounded rectangles

### DIFF
--- a/crates/vide/src/api/instance.rs
+++ b/crates/vide/src/api/instance.rs
@@ -5,6 +5,7 @@ use bytemuck::{Pod, Zeroable};
 pub struct Instance {
   pub matrix: [[f32; 4]; 4],
   pub color: [f32; 4],
+  pub radius: f32,
 }
 
 impl Instance {
@@ -37,6 +38,11 @@ impl Instance {
           format: wgpu::VertexFormat::Float32x4,
           offset: std::mem::size_of::<[f32; 16]>() as wgpu::BufferAddress,
           shader_location: 9,
+        },
+        wgpu::VertexAttribute {
+          format: wgpu::VertexFormat::Float32,
+          offset: std::mem::size_of::<[f32; 20]>() as wgpu::BufferAddress,
+          shader_location: 10,
         },
       ],
     }

--- a/crates/vide/src/api/rect.rs
+++ b/crates/vide/src/api/rect.rs
@@ -10,6 +10,7 @@ pub struct Rect {
   pub position: Animated<(f32, f32)>,
   pub size: Animated<(f32, f32)>,
   pub color: Animated<Color>,
+  pub radius: Animated<f32>,
   pub start: f64,
   pub end: f64,
 }
@@ -55,6 +56,7 @@ impl Clip for Rect {
     let position = self.position.evaluate(frame);
     let size = self.size.evaluate(frame);
     let color = self.color.evaluate(frame);
+    let radius = self.radius.evaluate(frame);
 
     let shader = Shader::new(renderer, include_str!("rect.wgsl").into());
     let mut mesh = Mesh::new(
@@ -88,6 +90,7 @@ impl Clip for Rect {
         * OPENGL_TO_WGPU_MATRIX)
         .into(),
       color: color.into(),
+      radius,
     };
 
     mesh.render(
@@ -103,6 +106,7 @@ pub struct RectBuilder {
   position: Option<Animated<(f32, f32)>>,
   size: Option<Animated<(f32, f32)>>,
   color: Option<Animated<Color>>,
+  radius: Option<Animated<f32>>,
   start: f64,
   end: f64,
 }
@@ -113,6 +117,7 @@ impl Default for RectBuilder {
       position: None,
       size: None,
       color: None,
+      radius: None,
       start: 0.0,
       end: f64::INFINITY,
     }
@@ -135,6 +140,11 @@ impl RectBuilder {
     self
   }
 
+  pub fn rounded(mut self, radius: impl Into<Animated<f32>>) -> Self {
+    self.radius = Some(radius.into());
+    self
+  }
+
   pub fn timing(mut self, range: impl Into<std::ops::Range<f64>>) -> Self {
     let range = range.into();
     self.start = range.start;
@@ -147,6 +157,7 @@ impl RectBuilder {
       position: self.position.unwrap_or_else(|| unanimated!((0.0, 0.0))),
       size: self.size.unwrap_or_else(|| unanimated!((100.0, 100.0))),
       color: self.color.unwrap_or_else(|| unanimated!(Color::WHITE)),
+      radius: self.radius.unwrap_or_else(|| unanimated!(0.0)),
       start: self.start,
       end: self.end,
     }

--- a/examples/animation/src/main.rs
+++ b/examples/animation/src/main.rs
@@ -22,6 +22,7 @@ fn main() {
           .keyframe(Rel(0.3), ease::IN_QUADRATIC, rgb8!(0x00, 0xda, 0x37))
           .build(),
       )
+      .rounded(0.3) // 30%
       .timing(1.0..5.0)
       .build(),
   );
@@ -38,6 +39,7 @@ fn main() {
           .keyframe(Rel(0.3), ease::IN_QUADRATIC, rgb8!(0x00, 0xda, 0x37))
           .build(),
       )
+      .rounded(0.3) // 30%
       .timing(1.0..5.0)
       .build(),
   );
@@ -54,6 +56,7 @@ fn main() {
           .keyframe(Rel(0.3), ease::IN_QUADRATIC, rgb8!(0x00, 0xda, 0x37))
           .build(),
       )
+      .rounded(0.3) // 30%
       .timing(1.0..5.0)
       .build(),
   );

--- a/examples/easing/src/main.rs
+++ b/examples/easing/src/main.rs
@@ -45,6 +45,7 @@ fn main() {
         )
         .size((rect_size, rect_size))
         .color(rgb8!(0xda, 0x00, 0x37))
+        .rounded(0.2) // 20%
         .timing(0.0..5.0)
         .build(),
     );


### PR DESCRIPTION
This pull request introduces a new feature to support rounded rectangles in the rendering system. The changes span multiple files and include modifications to the `Instance` and `Rect` structures, as well as updates to shaders and example code.

### New Feature: Rounded Rectangles

* [`crates/vide/src/api/instance.rs`](diffhunk://#diff-7fda825316a7c0080e90ac1b614e24f3f973fd7fbc5c340f2ceeb43eaf831b68R8): Added a `radius` field to the `Instance` struct and updated the vertex attributes to include the radius. [[1]](diffhunk://#diff-7fda825316a7c0080e90ac1b614e24f3f973fd7fbc5c340f2ceeb43eaf831b68R8) [[2]](diffhunk://#diff-7fda825316a7c0080e90ac1b614e24f3f973fd7fbc5c340f2ceeb43eaf831b68R42-R46)
* `crates/vide/src/api/rect.rs`: 
  * Added a `radius` field to the `Rect` struct and updated the `Clip` implementation to evaluate and use the radius. [[1]](diffhunk://#diff-b35203375c0227c5e9ab5d56ece22ec93bd235cc6a3c01d48ae61323c0fdb504R13) [[2]](diffhunk://#diff-b35203375c0227c5e9ab5d56ece22ec93bd235cc6a3c01d48ae61323c0fdb504R59) [[3]](diffhunk://#diff-b35203375c0227c5e9ab5d56ece22ec93bd235cc6a3c01d48ae61323c0fdb504R93)
  * Added a `radius` field to the `RectBuilder` struct and provided a new method `rounded` to set the radius. Updated the `build` method to include the radius. [[1]](diffhunk://#diff-b35203375c0227c5e9ab5d56ece22ec93bd235cc6a3c01d48ae61323c0fdb504R109) [[2]](diffhunk://#diff-b35203375c0227c5e9ab5d56ece22ec93bd235cc6a3c01d48ae61323c0fdb504R120) [[3]](diffhunk://#diff-b35203375c0227c5e9ab5d56ece22ec93bd235cc6a3c01d48ae61323c0fdb504R143-R147) [[4]](diffhunk://#diff-b35203375c0227c5e9ab5d56ece22ec93bd235cc6a3c01d48ae61323c0fdb504R160)

### Shader Updates

* `crates/vide/src/api/rect.wgsl`: 
  * Added a `radius` field to the `InstanceInput` struct and updated the vertex shader to pass the radius to the fragment shader. [[1]](diffhunk://#diff-c511f9ffbe1f2e947fe68d3cd8fc274efac0a53286c91a930865d70cbe741505R20-R27) [[2]](diffhunk://#diff-c511f9ffbe1f2e947fe68d3cd8fc274efac0a53286c91a930865d70cbe741505R46-R62)
  * Updated the fragment shader to use the radius for rendering rounded corners using signed distance functions (SDF).

### Example Code

* `examples/animation/src/main.rs` and `examples/easing/src/main.rs`: Updated example code to demonstrate the use of the new `rounded` method for creating rectangles with rounded corners. [[1]](diffhunk://#diff-63354c1282affb0f07b3e679b381c04872026f8380ef0720576f59380804c299R25) [[2]](diffhunk://#diff-63354c1282affb0f07b3e679b381c04872026f8380ef0720576f59380804c299R42) [[3]](diffhunk://#diff-63354c1282affb0f07b3e679b381c04872026f8380ef0720576f59380804c299R59) [[4]](diffhunk://#diff-73d8de5d8ce6ef5f45296b83ec95077cd063c120ca5a18cc80491c9519b39462R48)